### PR TITLE
fix: should check squashed status whether or not the number of commits in PR is 1

### DIFF
--- a/src/cherrypick.ts
+++ b/src/cherrypick.ts
@@ -130,23 +130,17 @@ export class CherryPick {
 
       let commitShasToCherryPick: string[];
 
-      if (mainpr.commits == 1) {
-        // if the Pr only has one commit, we don't care
-        // if the Pr was squashed or rebased
-        commitShasToCherryPick = commitShas;
+      // find out if "squashed and merged" or "rebased and merged"
+      if (await this.github.isSquashed(mainpr)) {
+        console.log("PR was squashed and merged");
+        // if squashed, then use the merge commit sha
+        commitShasToCherryPick = [
+          await this.github.getMergeCommitSha(mainpr),
+        ]?.filter(Boolean) as string[];
       } else {
-        // find out if "squashed and merged" or "rebased and merged"
-        if (await this.github.isSquashed(mainpr)) {
-          console.log("PR was squashed and merged");
-          // if squashed, then use the merge commit sha
-          commitShasToCherryPick = [
-            await this.github.getMergeCommitSha(mainpr),
-          ]?.filter(Boolean) as string[];
-        } else {
-          // if rebased, then use all the commits from the original PR
-          console.log("PR was rebased and merged");
-          commitShasToCherryPick = commitShas;
-        }
+        // if rebased, then use all the commits from the original PR
+        console.log("PR was rebased and merged");
+        commitShasToCherryPick = commitShas;
       }
 
       if (


### PR DESCRIPTION
## Description

It feels like there is still a great possibility of squash merging if a PR only contains 1 commit. Imagine a scenario that the admin of the repo wants to modify the commit message style/description before merging.

So the check of PR commit number seems unnecessary, and incorrect under the squash merging scenario.